### PR TITLE
[codex] specify investigation workflow contracts

### DIFF
--- a/docs/investigation-workflow.md
+++ b/docs/investigation-workflow.md
@@ -57,12 +57,12 @@ Execution type:
 - deterministic
 
 Stop point:
-- valid to stop here if the repository cannot be fetched or authenticated access is missing
+- valid to stop here and inspect the snapshot metadata before structural inventory begins
 
 ## Stage 2: Repository Inventory
 
 Purpose:
-- create a structural inventory of the repository without inferring product behavior yet
+- create a structural inventory of the repository, including source-derived structural signals, without inferring product behavior yet
 
 Inputs:
 - `source_snapshot`
@@ -76,6 +76,7 @@ Outputs:
 - detected languages
 - manifest files
 - build systems and package managers
+- source-derived structural signals such as detectable public interfaces, entry points, schema surfaces, or exported modules when those signals can be collected deterministically
 - tests, docs, CI files, entry points, and automation signals
 - ignored or skipped path summaries
 
@@ -88,7 +89,7 @@ Stop point:
 ## Stage 3: Readable-Text Extraction
 
 Purpose:
-- extract explanatory text that does not live in source code
+- extract explanatory text and human-authored repository evidence that complements the structural inventory without requiring Codex reasoning
 
 Inputs:
 - `source_snapshot`
@@ -101,7 +102,7 @@ Outputs:
 - detected README files
 - docs directory entries
 - Markdown, reStructuredText, changelogs, ADRs, and plain-text artifacts
-- normalized summaries of feature descriptions, setup steps, API usage, deployment notes, and constraints
+- normalized text blocks describing feature areas, setup steps, API usage, deployment notes, and constraints
 - provenance for each extracted text artifact
 
 Execution type:

--- a/docs/mvp-spec.md
+++ b/docs/mvp-spec.md
@@ -60,12 +60,13 @@ Codex is the planning engine. GitHub mutations are not delegated to Codex.
 
 The MVP uses a staged investigation pipeline instead of a single scan. The intended stages are:
 
-1. inventory
-2. readable-text extraction
-3. architecture synthesis
-4. behavior inference
-5. interface and operations analysis
-6. planning context assembly
+1. source snapshot
+2. repository inventory
+3. readable-text extraction
+4. architecture synthesis
+5. behavior inference
+6. interface and operations analysis
+7. planning context assembly
 
 Each stage produces a typed artifact that can be inspected during dry runs.
 


### PR DESCRIPTION
## Summary

- add a dedicated investigation workflow document under `docs/investigation-workflow.md`
- specify the named investigation stages, typed artifacts, deterministic vs Codex-driven boundaries, and inspection points
- link the new workflow contract from the MVP spec so the stage model is discoverable from the existing foundation docs

## Why

Issue `#21` requires a concrete stage and artifact contract for the investigation pipeline before the extractor, planner, and prompt work can be implemented coherently.

This PR is intentionally stacked on top of #26 because it builds directly on the MVP spec introduced there.

Refs #21

## Validation

- reviewed the workflow document against the issue acceptance criteria
- verified the MVP spec links to the new workflow document
