### PR TITLE
[codex] clone and snapshot source repositories safely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 build/
 *.egg-info/
 .DS_Store
+.issue-foundry/

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ The first implementation target is documented in [docs/mvp-spec.md](docs/mvp-spe
 ## Input Contract
 
 The operator input rules and target naming behavior are documented in [docs/input-contract.md](docs/input-contract.md).
+
+## Current Planning Flow
+
+The `plan` command currently validates operator input, materializes a source snapshot, and writes a `source-snapshot.json` artifact under `.issue-foundry/artifacts/...` before later investigation stages are added.

--- a/src/issue_foundry/cli.py
+++ b/src/issue_foundry/cli.py
@@ -92,6 +92,11 @@ def plan_command(
         "--target-runtime",
         help="Preferred runtime or platform for the clean-room rebuild plan.",
     ),
+    preserve_workspace: bool = typer.Option(
+        False,
+        "--preserve-workspace/--cleanup-workspace",
+        help="Keep the checked-out source workspace under the output directory for debugging.",
+    ),
     architecture_constraint: Optional[List[str]] = typer.Option(
         None,
         "--architecture-constraint",
@@ -106,6 +111,7 @@ def plan_command(
         target_framework,
         target_runtime,
         architecture_constraint or (),
+        preserve_workspace,
     )
 
 

--- a/src/issue_foundry/commands/plan.py
+++ b/src/issue_foundry/commands/plan.py
@@ -6,6 +6,7 @@ import typer
 
 from issue_foundry.config import IssueFoundrySettings
 from issue_foundry.inputs import InputValidationError, build_planning_input
+from issue_foundry.source_snapshot import SourceSnapshotError, materialize_source_snapshot
 
 
 def plan(
@@ -16,6 +17,7 @@ def plan(
     target_framework: Optional[str],
     target_runtime: Optional[str],
     architecture_constraints: Sequence[str],
+    preserve_workspace: bool,
 ) -> None:
     try:
         planning_input = build_planning_input(
@@ -29,23 +31,38 @@ def plan(
         )
     except InputValidationError as exc:
         raise typer.BadParameter(str(exc), param_hint=exc.field) from exc
+    try:
+        with materialize_source_snapshot(
+            settings,
+            planning_input.source_repository,
+            preserve_workspace=preserve_workspace,
+        ) as snapshot:
+            target_request = planning_input.target_request
 
-    target_request = planning_input.target_request
-
-    typer.echo("Issue Foundry plan scaffold")
-    typer.echo(f"source_repo: {planning_input.source_repository.full_name}")
-    typer.echo(f"source_url: {planning_input.source_repository.canonical_url}")
-    typer.echo(f"default_branch: {planning_input.source_repository.default_branch}")
-    typer.echo(f"display_name: {planning_input.source_repository.display_name}")
-    typer.echo(f"target_repository_name: {target_request.repository_name}")
-    typer.echo(f"target_repository_name_source: {target_request.repository_name_source}")
-    typer.echo(f"target_language: {target_request.language or 'source-aligned defaults'}")
-    typer.echo(f"target_framework: {target_request.framework or 'source-aligned defaults'}")
-    typer.echo(f"target_runtime: {target_request.runtime or 'source-aligned defaults'}")
-    typer.echo(
-        "architecture_constraints: "
-        + (", ".join(target_request.architecture_constraints) if target_request.architecture_constraints else "none")
-    )
-    typer.echo(f"codex_model: {settings.codex_model}")
-    typer.echo(f"output_dir: {settings.output_dir}")
-    typer.echo("next_step: wire staged investigation against the typed planning input")
+            typer.echo("Issue Foundry plan scaffold")
+            typer.echo(f"source_repo: {planning_input.source_repository.full_name}")
+            typer.echo(f"source_url: {planning_input.source_repository.canonical_url}")
+            typer.echo(f"default_branch: {planning_input.source_repository.default_branch}")
+            typer.echo(f"display_name: {planning_input.source_repository.display_name}")
+            typer.echo(f"target_repository_name: {target_request.repository_name}")
+            typer.echo(f"target_repository_name_source: {target_request.repository_name_source}")
+            typer.echo(f"target_language: {target_request.language or 'source-aligned defaults'}")
+            typer.echo(f"target_framework: {target_request.framework or 'source-aligned defaults'}")
+            typer.echo(f"target_runtime: {target_request.runtime or 'source-aligned defaults'}")
+            typer.echo(
+                "architecture_constraints: "
+                + (", ".join(target_request.architecture_constraints) if target_request.architecture_constraints else "none")
+            )
+            typer.echo(f"snapshot_commit_sha: {snapshot.artifact.commit_sha}")
+            typer.echo(f"snapshot_resolved_ref: {snapshot.artifact.resolved_ref}")
+            typer.echo(f"snapshot_fetched_at: {snapshot.artifact.fetched_at.isoformat()}")
+            typer.echo(f"snapshot_workspace: {snapshot.workspace_path}")
+            typer.echo(f"snapshot_workspace_retained: {'yes' if snapshot.artifact.workspace_retained else 'no'}")
+            typer.echo(f"snapshot_artifact: {snapshot.artifact_path}")
+            typer.echo(f"snapshot_ignored_paths: {len(snapshot.artifact.ignored_paths)} matched")
+            typer.echo(f"codex_model: {settings.codex_model}")
+            typer.echo(f"output_dir: {settings.output_dir}")
+            typer.echo("next_step: wire repository inventory extraction against the snapshot artifact")
+    except SourceSnapshotError as exc:
+        typer.secho(f"Error: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc

--- a/src/issue_foundry/source_snapshot.py
+++ b/src/issue_foundry/source_snapshot.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory, mkdtemp
+from typing import Any, Iterator, Optional, Sequence
+
+from pydantic import BaseModel, ConfigDict
+
+from issue_foundry.config import IssueFoundrySettings
+from issue_foundry.inputs import SourceRepositoryInput
+
+
+IGNORED_PATH_PARTS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        ".venv",
+        ".yarn",
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        "build",
+        "coverage",
+        "dist",
+        "node_modules",
+        "target",
+        "vendor",
+        "venv",
+    }
+)
+IGNORED_FILE_NAMES = frozenset({".DS_Store"})
+
+
+class SourceSnapshotError(RuntimeError):
+    """Raised when a source repository snapshot cannot be created safely."""
+
+
+class SourceSnapshotArtifact(BaseModel):
+    """Typed artifact describing the materialized source snapshot."""
+
+    model_config = ConfigDict(frozen=True)
+
+    source_repository: SourceRepositoryInput
+    resolved_ref: str
+    commit_sha: str
+    fetched_at: datetime
+    workspace_path: str
+    workspace_retained: bool
+    ignore_rules: tuple[str, ...]
+    ignored_paths: tuple[str, ...]
+
+
+@dataclass
+class MaterializedSourceSnapshot:
+    """A materialized repository snapshot plus the persisted artifact path."""
+
+    artifact: SourceSnapshotArtifact
+    artifact_path: Path
+    workspace_path: Path
+    _temporary_directory: Any = None
+
+    def cleanup(self) -> None:
+        if self._temporary_directory is not None:
+            self._temporary_directory.cleanup()
+            self._temporary_directory = None
+
+
+@contextmanager
+def materialize_source_snapshot(
+    settings: IssueFoundrySettings,
+    source_repository: SourceRepositoryInput,
+    *,
+    preserve_workspace: bool = False,
+    requested_ref: Optional[str] = None,
+) -> Iterator[MaterializedSourceSnapshot]:
+    snapshot = create_source_snapshot(
+        settings,
+        source_repository,
+        preserve_workspace=preserve_workspace,
+        requested_ref=requested_ref,
+    )
+
+    try:
+        yield snapshot
+    finally:
+        snapshot.cleanup()
+
+
+def create_source_snapshot(
+    settings: IssueFoundrySettings,
+    source_repository: SourceRepositoryInput,
+    *,
+    preserve_workspace: bool = False,
+    requested_ref: Optional[str] = None,
+) -> MaterializedSourceSnapshot:
+    output_dir = settings.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    workspace_path, temporary_directory = _allocate_workspace(output_dir, source_repository, preserve_workspace)
+
+    try:
+        _clone_repository(source_repository.canonical_url, workspace_path)
+        resolved_ref = _checkout_snapshot_ref(
+            workspace_path,
+            requested_ref=requested_ref,
+            default_branch=source_repository.default_branch,
+        )
+        commit_sha = _run_git_capture(["rev-parse", "HEAD"], cwd=workspace_path)
+        fetched_at = datetime.now(timezone.utc)
+        ignored_paths = collect_ignored_paths(workspace_path)
+        artifact = SourceSnapshotArtifact(
+            source_repository=source_repository,
+            resolved_ref=resolved_ref,
+            commit_sha=commit_sha,
+            fetched_at=fetched_at,
+            workspace_path=str(workspace_path),
+            workspace_retained=preserve_workspace,
+            ignore_rules=tuple(sorted(IGNORED_PATH_PARTS)) + tuple(sorted(IGNORED_FILE_NAMES)),
+            ignored_paths=ignored_paths,
+        )
+        artifact_path = write_source_snapshot_artifact(output_dir, artifact)
+        return MaterializedSourceSnapshot(
+            artifact=artifact,
+            artifact_path=artifact_path,
+            workspace_path=workspace_path,
+            _temporary_directory=temporary_directory,
+        )
+    except Exception:
+        if temporary_directory is not None:
+            temporary_directory.cleanup()
+        else:
+            shutil.rmtree(workspace_path, ignore_errors=True)
+        raise
+
+
+def write_source_snapshot_artifact(output_dir: Path, artifact: SourceSnapshotArtifact) -> Path:
+    artifact_dir = output_dir / "artifacts" / artifact.source_repository.owner / artifact.source_repository.name
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact_dir / "source-snapshot.json"
+    artifact_path.write_text(artifact.model_dump_json(indent=2), encoding="utf-8")
+    return artifact_path
+
+
+def should_ignore_snapshot_path(relative_path: Path) -> bool:
+    if relative_path.name in IGNORED_FILE_NAMES:
+        return True
+
+    return any(part in IGNORED_PATH_PARTS for part in relative_path.parts)
+
+
+def collect_ignored_paths(workspace_path: Path, *, limit: int = 25) -> tuple[str, ...]:
+    ignored_paths: list[str] = []
+
+    for current_root, dirnames, filenames in os.walk(workspace_path, topdown=True):
+        root_path = Path(current_root)
+        relative_root = root_path.relative_to(workspace_path)
+
+        kept_dirnames: list[str] = []
+        for dirname in sorted(dirnames):
+            relative_dir = Path(dirname) if relative_root == Path(".") else relative_root / dirname
+            if should_ignore_snapshot_path(relative_dir):
+                ignored_paths.append(f"{relative_dir.as_posix()}/")
+                if len(ignored_paths) >= limit:
+                    return tuple(ignored_paths)
+            else:
+                kept_dirnames.append(dirname)
+        dirnames[:] = kept_dirnames
+
+        for filename in sorted(filenames):
+            relative_file = Path(filename) if relative_root == Path(".") else relative_root / filename
+            if should_ignore_snapshot_path(relative_file):
+                ignored_paths.append(relative_file.as_posix())
+                if len(ignored_paths) >= limit:
+                    return tuple(ignored_paths)
+
+    return tuple(ignored_paths)
+
+
+def _allocate_workspace(
+    output_dir: Path,
+    source_repository: SourceRepositoryInput,
+    preserve_workspace: bool,
+) -> tuple[Path, Any]:
+    workspace_root = output_dir / "workspaces" / ("preserved" if preserve_workspace else "tmp")
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    slug = _slugify(source_repository.full_name)
+    if preserve_workspace:
+        return Path(mkdtemp(prefix=f"{slug}-", dir=workspace_root)), None
+
+    temporary_directory = TemporaryDirectory(prefix=f"{slug}-", dir=workspace_root)
+    return Path(temporary_directory.name), temporary_directory
+
+
+def _checkout_snapshot_ref(workspace_path: Path, *, requested_ref: Optional[str], default_branch: str) -> str:
+    resolved_ref = (requested_ref or default_branch).strip()
+    candidates = [f"origin/{resolved_ref}", resolved_ref]
+
+    for candidate in candidates:
+        try:
+            _run_git(
+                ["checkout", "--quiet", "--force", "--detach", candidate],
+                cwd=workspace_path,
+            )
+            return resolved_ref
+        except SourceSnapshotError:
+            continue
+
+    raise SourceSnapshotError(f"Unable to checkout source ref '{resolved_ref}'.")
+
+
+def _clone_repository(source_url: str, workspace_path: Path) -> None:
+    _run_git(
+        ["clone", "--quiet", "--no-checkout", source_url, str(workspace_path)],
+        cwd=workspace_path.parent,
+    )
+
+
+def _run_git_capture(args: Sequence[str], *, cwd: Path) -> str:
+    completed = _run_git(args, cwd=cwd)
+    return completed.strip()
+
+
+def _run_git(args: Sequence[str], *, cwd: Path) -> str:
+    command = ["git", *args]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise SourceSnapshotError("The git executable is required to snapshot source repositories.") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() or exc.stdout.strip() or "unknown git error"
+        raise SourceSnapshotError(f"Git failed while preparing the source snapshot: {stderr}") from exc
+
+    return completed.stdout
+
+
+def _slugify(value: str) -> str:
+    slug = value.lower().replace("/", "-")
+    return "".join(character if character.isalnum() or character in {"-", "_"} else "-" for character in slug)

--- a/src/issue_foundry/source_snapshot.py
+++ b/src/issue_foundry/source_snapshot.py
@@ -157,7 +157,7 @@ def should_ignore_snapshot_path(relative_path: Path) -> bool:
     return any(part in IGNORED_PATH_PARTS for part in relative_path.parts)
 
 
-def collect_ignored_paths(workspace_path: Path, *, limit: int = 25) -> tuple[str, ...]:
+def collect_ignored_paths(workspace_path: Path, *, limit: int = 200) -> tuple[str, ...]:
     ignored_paths: list[str] = []
 
     for current_root, dirnames, filenames in os.walk(workspace_path, topdown=True):
@@ -166,7 +166,7 @@ def collect_ignored_paths(workspace_path: Path, *, limit: int = 25) -> tuple[str
 
         kept_dirnames: list[str] = []
         for dirname in sorted(dirnames):
-            relative_dir = Path(dirname) if relative_root == Path(".") else relative_root / dirname
+            relative_dir = relative_root / dirname
             if should_ignore_snapshot_path(relative_dir):
                 ignored_paths.append(f"{relative_dir.as_posix()}/")
                 if len(ignored_paths) >= limit:
@@ -176,7 +176,7 @@ def collect_ignored_paths(workspace_path: Path, *, limit: int = 25) -> tuple[str
         dirnames[:] = kept_dirnames
 
         for filename in sorted(filenames):
-            relative_file = Path(filename) if relative_root == Path(".") else relative_root / filename
+            relative_file = relative_root / filename
             if should_ignore_snapshot_path(relative_file):
                 ignored_paths.append(relative_file.as_posix())
                 if len(ignored_paths) >= limit:

--- a/tests/test_source_snapshot.py
+++ b/tests/test_source_snapshot.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from issue_foundry.config import IssueFoundrySettings
+from issue_foundry.inputs import SourceRepositoryInput
+from issue_foundry.source_snapshot import materialize_source_snapshot, should_ignore_snapshot_path
+
+
+def test_should_ignore_snapshot_path_matches_expected_noise() -> None:
+    assert should_ignore_snapshot_path(Path(".git/config"))
+    assert should_ignore_snapshot_path(Path("node_modules/react/index.js"))
+    assert should_ignore_snapshot_path(Path("dist/app.js"))
+    assert should_ignore_snapshot_path(Path("vendor/cache.tar"))
+    assert not should_ignore_snapshot_path(Path("src/app.py"))
+    assert not should_ignore_snapshot_path(Path("docs/README.md"))
+
+
+def test_materialize_source_snapshot_cleans_temp_workspace(tmp_path: Path) -> None:
+    source_repo_path, commit_sha = create_source_repo(tmp_path)
+    settings = IssueFoundrySettings(output_dir=tmp_path / ".issue-foundry")
+    source_repository = build_source_repository_input(source_repo_path)
+
+    with materialize_source_snapshot(settings, source_repository, preserve_workspace=False) as snapshot:
+        assert snapshot.workspace_path.exists()
+        assert snapshot.artifact.commit_sha == commit_sha
+        assert snapshot.artifact.resolved_ref == "main"
+        assert snapshot.artifact.workspace_retained is False
+        assert "node_modules/" in snapshot.artifact.ignored_paths
+        artifact_payload = json.loads(snapshot.artifact_path.read_text(encoding="utf-8"))
+        assert artifact_payload["commit_sha"] == commit_sha
+        assert artifact_payload["resolved_ref"] == "main"
+
+    assert not snapshot.workspace_path.exists()
+
+
+def test_materialize_source_snapshot_preserves_workspace_when_requested(tmp_path: Path) -> None:
+    source_repo_path, commit_sha = create_source_repo(tmp_path)
+    settings = IssueFoundrySettings(output_dir=tmp_path / ".issue-foundry")
+    source_repository = build_source_repository_input(source_repo_path)
+
+    with materialize_source_snapshot(settings, source_repository, preserve_workspace=True) as snapshot:
+        preserved_workspace = snapshot.workspace_path
+        assert preserved_workspace.exists()
+        assert snapshot.artifact.commit_sha == commit_sha
+        assert snapshot.artifact.workspace_retained is True
+
+    assert preserved_workspace.exists()
+    shutil.rmtree(preserved_workspace)
+
+
+def create_source_repo(tmp_path: Path) -> tuple[Path, str]:
+    source_repo_path = tmp_path / "source-repo"
+    source_repo_path.mkdir()
+    run_git(["init", "-b", "main"], cwd=source_repo_path)
+    run_git(["config", "user.email", "codex@example.com"], cwd=source_repo_path)
+    run_git(["config", "user.name", "Codex"], cwd=source_repo_path)
+
+    (source_repo_path / "src").mkdir()
+    (source_repo_path / "src" / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    (source_repo_path / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (source_repo_path / "node_modules" / "react").mkdir(parents=True)
+    (source_repo_path / "node_modules" / "react" / "index.js").write_text("module.exports = {};\n", encoding="utf-8")
+
+    run_git(["add", "."], cwd=source_repo_path)
+    run_git(["commit", "-m", "initial snapshot"], cwd=source_repo_path)
+    commit_sha = run_git_capture(["rev-parse", "HEAD"], cwd=source_repo_path)
+    return source_repo_path, commit_sha
+
+
+def build_source_repository_input(source_repo_path: Path) -> SourceRepositoryInput:
+    return SourceRepositoryInput(
+        raw_url=str(source_repo_path),
+        canonical_url=str(source_repo_path),
+        owner="example",
+        name="demo",
+        full_name="example/demo",
+        default_branch="main",
+        display_name="example/demo",
+    )
+
+
+def run_git_capture(args: list[str], *, cwd: Path) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def run_git(args: list[str], *, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
## Summary
- add a source snapshot stage that clones a public repository into a controlled workspace and persists a typed `source-snapshot.json` artifact
- add deterministic ignore rules plus cleanup and preserve-workspace behavior for temporary source checkouts
- wire the `plan` command to materialize and report the snapshot before later investigation stages run

## Why
Issue `#4` needs a stable, traceable repository snapshot before inventory extraction and later analysis stages can build on it safely.

## Validation
- `PYTHONPATH=src .venv/bin/pytest -q`
- `PYTHONPATH=src .venv/bin/python -m issue_foundry plan https://github.com/octocat/Hello-World --target-language python`
- `PYTHONPATH=src .venv/bin/python -m issue_foundry plan https://github.com/octocat/Hello-World --target-language python --preserve-workspace`

Closes #4