### PR TITLE
[codex] build repository inventory extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ The operator input rules and target naming behavior are documented in [docs/inpu
 
 ## Current Planning Flow
 
-The `plan` command currently validates operator input, materializes a source snapshot, and writes a `source-snapshot.json` artifact under `.issue-foundry/artifacts/...` before later investigation stages are added.
+The `plan` command currently validates operator input, materializes a source snapshot, and writes both `source-snapshot.json` and `repository-inventory.json` artifacts under `.issue-foundry/artifacts/...` before later investigation stages are added.

--- a/src/issue_foundry/commands/plan.py
+++ b/src/issue_foundry/commands/plan.py
@@ -6,6 +6,7 @@ import typer
 
 from issue_foundry.config import IssueFoundrySettings
 from issue_foundry.inputs import InputValidationError, build_planning_input
+from issue_foundry.repository_inventory import build_repository_inventory
 from issue_foundry.source_snapshot import SourceSnapshotError, materialize_source_snapshot
 
 
@@ -37,6 +38,7 @@ def plan(
             planning_input.source_repository,
             preserve_workspace=preserve_workspace,
         ) as snapshot:
+            repository_inventory = build_repository_inventory(snapshot)
             target_request = planning_input.target_request
 
             typer.echo("Issue Foundry plan scaffold")
@@ -60,9 +62,24 @@ def plan(
             typer.echo(f"snapshot_workspace_retained: {'yes' if snapshot.artifact.workspace_retained else 'no'}")
             typer.echo(f"snapshot_artifact: {snapshot.artifact_path}")
             typer.echo(f"snapshot_ignored_paths: {len(snapshot.artifact.ignored_paths)} matched")
+            typer.echo(f"inventory_total_files: {repository_inventory.artifact.total_files}")
+            typer.echo(
+                "inventory_detected_languages: "
+                + (
+                    ", ".join(repository_inventory.artifact.detected_languages)
+                    if repository_inventory.artifact.detected_languages
+                    else "none"
+                )
+            )
+            typer.echo(f"inventory_manifest_files: {len(repository_inventory.artifact.manifest_files)}")
+            typer.echo(f"inventory_test_files: {len(repository_inventory.artifact.test_files)}")
+            typer.echo(f"inventory_doc_files: {len(repository_inventory.artifact.documentation_files)}")
+            typer.echo(f"inventory_ci_files: {len(repository_inventory.artifact.ci_files)}")
+            typer.echo(f"inventory_entry_points: {len(repository_inventory.artifact.entry_points)}")
+            typer.echo(f"inventory_artifact: {repository_inventory.artifact_path}")
             typer.echo(f"codex_model: {settings.codex_model}")
             typer.echo(f"output_dir: {settings.output_dir}")
-            typer.echo("next_step: wire repository inventory extraction against the snapshot artifact")
+            typer.echo("next_step: wire readable-text extraction against the repository inventory artifact")
     except SourceSnapshotError as exc:
         typer.secho(f"Error: {exc}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=1) from exc

--- a/src/issue_foundry/repository_inventory.py
+++ b/src/issue_foundry/repository_inventory.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import os
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from pydantic import BaseModel, ConfigDict
+
+from issue_foundry.source_snapshot import MaterializedSourceSnapshot, should_ignore_snapshot_path
+
+
+LANGUAGE_BY_EXTENSION = {
+    ".c": "C",
+    ".cc": "C++",
+    ".cpp": "C++",
+    ".cs": "C#",
+    ".css": "CSS",
+    ".ex": "Elixir",
+    ".exs": "Elixir",
+    ".go": "Go",
+    ".html": "HTML",
+    ".java": "Java",
+    ".js": "JavaScript",
+    ".json": "JSON",
+    ".jsx": "JavaScript",
+    ".kt": "Kotlin",
+    ".kts": "Kotlin",
+    ".md": "Markdown",
+    ".php": "PHP",
+    ".pl": "Perl",
+    ".py": "Python",
+    ".rb": "Ruby",
+    ".rs": "Rust",
+    ".rst": "reStructuredText",
+    ".scss": "SCSS",
+    ".sh": "Shell",
+    ".sql": "SQL",
+    ".swift": "Swift",
+    ".toml": "TOML",
+    ".ts": "TypeScript",
+    ".tsx": "TypeScript",
+    ".txt": "Text",
+    ".yaml": "YAML",
+    ".yml": "YAML",
+}
+LANGUAGE_BY_FILENAME = {
+    "Dockerfile": "Docker",
+    "Jenkinsfile": "Groovy",
+    "Makefile": "Make",
+}
+BUILD_SYSTEMS_BY_FILE = {
+    "Cargo.toml": ("cargo",),
+    "Dockerfile": ("docker",),
+    "Gemfile": ("bundler",),
+    "Makefile": ("make",),
+    "Taskfile.yml": ("taskfile",),
+    "Taskfile.yaml": ("taskfile",),
+    "build.gradle": ("gradle",),
+    "build.gradle.kts": ("gradle",),
+    "composer.json": ("composer",),
+    "go.mod": ("go",),
+    "mix.exs": ("mix",),
+    "package.json": ("node",),
+    "pom.xml": ("maven",),
+    "pyproject.toml": ("python",),
+    "requirements.txt": ("python",),
+    "setup.py": ("python",),
+}
+PACKAGE_MANAGERS_BY_FILE = {
+    "Cargo.lock": ("cargo",),
+    "Cargo.toml": ("cargo",),
+    "Gemfile.lock": ("bundler",),
+    "Gemfile": ("bundler",),
+    "composer.json": ("composer",),
+    "go.mod": ("go",),
+    "package-lock.json": ("npm",),
+    "package.json": ("npm",),
+    "pnpm-lock.yaml": ("pnpm",),
+    "poetry.lock": ("poetry",),
+    "pyproject.toml": ("poetry", "pip"),
+    "requirements.txt": ("pip",),
+    "uv.lock": ("uv",),
+    "yarn.lock": ("yarn",),
+}
+MANIFEST_FILES = frozenset(set(BUILD_SYSTEMS_BY_FILE) | set(PACKAGE_MANAGERS_BY_FILE))
+TEXT_ARTIFACT_SUFFIXES = {".md", ".markdown", ".rst", ".txt"}
+ENTRY_POINT_FILE_NAMES = {
+    "app.py",
+    "cli.py",
+    "index.js",
+    "index.ts",
+    "main.go",
+    "main.py",
+    "manage.py",
+    "server.js",
+    "server.py",
+}
+ENTRY_POINT_DIRECTORIES = {"bin", "cmd"}
+AUTOMATION_FILE_NAMES = {"Dockerfile", "Justfile", "Makefile", "Taskfile.yml", "Taskfile.yaml"}
+
+
+class RepositoryInventoryArtifact(BaseModel):
+    """Deterministic structural inventory derived from a source snapshot."""
+
+    model_config = ConfigDict(frozen=True)
+
+    source_snapshot_artifact_path: str
+    analyzed_commit_sha: str
+    total_files: int
+    top_level_directories: tuple[str, ...]
+    top_level_files: tuple[str, ...]
+    file_counts_by_extension: dict[str, int]
+    file_counts_by_directory: dict[str, int]
+    language_file_counts: dict[str, int]
+    detected_languages: tuple[str, ...]
+    manifest_files: tuple[str, ...]
+    build_systems: tuple[str, ...]
+    package_managers: tuple[str, ...]
+    readme_files: tuple[str, ...]
+    documentation_files: tuple[str, ...]
+    plain_text_files: tuple[str, ...]
+    test_files: tuple[str, ...]
+    ci_files: tuple[str, ...]
+    automation_files: tuple[str, ...]
+    entry_points: tuple[str, ...]
+    skipped_paths: tuple[str, ...]
+
+
+@dataclass
+class PersistedRepositoryInventory:
+    artifact: RepositoryInventoryArtifact
+    artifact_path: Path
+
+
+def build_repository_inventory(snapshot: MaterializedSourceSnapshot) -> PersistedRepositoryInventory:
+    workspace_path = snapshot.workspace_path
+    extension_counts: Counter[str] = Counter()
+    directory_counts: Counter[str] = Counter()
+    language_counts: Counter[str] = Counter()
+    manifest_files: list[str] = []
+    readme_files: list[str] = []
+    documentation_files: list[str] = []
+    plain_text_files: list[str] = []
+    test_files: list[str] = []
+    ci_files: list[str] = []
+    automation_files: list[str] = []
+    entry_points: list[str] = []
+    top_level_directories: list[str] = []
+    top_level_files: list[str] = []
+    package_managers: set[str] = set()
+    build_systems: set[str] = set()
+
+    for child in sorted(workspace_path.iterdir(), key=lambda path: path.name):
+        if should_ignore_snapshot_path(Path(child.name)):
+            continue
+        if child.is_dir():
+            top_level_directories.append(child.name)
+        else:
+            top_level_files.append(child.name)
+
+    total_files = 0
+    for relative_file in _iter_inventory_files(workspace_path):
+        total_files += 1
+        file_name = relative_file.name
+        directory_key = relative_file.parent.as_posix() if relative_file.parent != Path(".") else "."
+        extension_key = relative_file.suffix.lower() or "<none>"
+
+        directory_counts[directory_key] += 1
+        extension_counts[extension_key] += 1
+
+        detected_language = detect_language(relative_file)
+        if detected_language:
+            language_counts[detected_language] += 1
+
+        relative_path_text = relative_file.as_posix()
+        lower_name = file_name.lower()
+        lower_path = relative_path_text.lower()
+
+        if lower_name.startswith("readme"):
+            readme_files.append(relative_path_text)
+        elif is_documentation_file(relative_file):
+            documentation_files.append(relative_path_text)
+
+        if relative_file.suffix.lower() in TEXT_ARTIFACT_SUFFIXES and relative_path_text not in readme_files:
+            plain_text_files.append(relative_path_text)
+
+        if is_test_file(relative_file):
+            test_files.append(relative_path_text)
+
+        if is_ci_file(relative_file):
+            ci_files.append(relative_path_text)
+
+        if is_automation_file(relative_file):
+            automation_files.append(relative_path_text)
+
+        if is_entry_point(relative_file):
+            entry_points.append(relative_path_text)
+
+        if file_name in MANIFEST_FILES:
+            manifest_files.append(relative_path_text)
+            build_systems.update(BUILD_SYSTEMS_BY_FILE.get(file_name, ()))
+            package_managers.update(PACKAGE_MANAGERS_BY_FILE.get(file_name, ()))
+
+        if lower_path.endswith("pnpm-lock.yaml") or lower_path.endswith("yarn.lock"):
+            package_managers.update(PACKAGE_MANAGERS_BY_FILE.get(file_name, ()))
+
+    artifact = RepositoryInventoryArtifact(
+        source_snapshot_artifact_path=str(snapshot.artifact_path),
+        analyzed_commit_sha=snapshot.artifact.commit_sha,
+        total_files=total_files,
+        top_level_directories=tuple(top_level_directories),
+        top_level_files=tuple(top_level_files),
+        file_counts_by_extension=_sorted_counter_dict(extension_counts),
+        file_counts_by_directory=_sorted_counter_dict(directory_counts),
+        language_file_counts=_sorted_counter_dict(language_counts),
+        detected_languages=tuple(sorted(language_counts)),
+        manifest_files=tuple(sorted(manifest_files)),
+        build_systems=tuple(sorted(build_systems)),
+        package_managers=tuple(sorted(package_managers)),
+        readme_files=tuple(sorted(readme_files)),
+        documentation_files=tuple(sorted(documentation_files)),
+        plain_text_files=tuple(sorted(plain_text_files)),
+        test_files=tuple(sorted(test_files)),
+        ci_files=tuple(sorted(ci_files)),
+        automation_files=tuple(sorted(set(automation_files))),
+        entry_points=tuple(sorted(set(entry_points))),
+        skipped_paths=snapshot.artifact.ignored_paths,
+    )
+
+    artifact_path = write_repository_inventory_artifact(snapshot, artifact)
+    return PersistedRepositoryInventory(artifact=artifact, artifact_path=artifact_path)
+
+
+def write_repository_inventory_artifact(
+    snapshot: MaterializedSourceSnapshot,
+    artifact: RepositoryInventoryArtifact,
+) -> Path:
+    artifact_dir = snapshot.artifact_path.parent
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact_dir / "repository-inventory.json"
+    artifact_path.write_text(artifact.model_dump_json(indent=2), encoding="utf-8")
+    return artifact_path
+
+
+def detect_language(relative_file: Path) -> str | None:
+    if relative_file.name in LANGUAGE_BY_FILENAME:
+        return LANGUAGE_BY_FILENAME[relative_file.name]
+    return LANGUAGE_BY_EXTENSION.get(relative_file.suffix.lower())
+
+
+def is_documentation_file(relative_file: Path) -> bool:
+    if relative_file.parts and relative_file.parts[0].lower() in {"doc", "docs"}:
+        return True
+    return relative_file.suffix.lower() in {".md", ".markdown", ".rst"} and relative_file.name.lower() != "readme.md"
+
+
+def is_test_file(relative_file: Path) -> bool:
+    parts = {part.lower() for part in relative_file.parts}
+    return "test" in parts or "tests" in parts or relative_file.name.lower().startswith("test_")
+
+
+def is_ci_file(relative_file: Path) -> bool:
+    path_text = relative_file.as_posix()
+    return (
+        path_text.startswith(".github/workflows/")
+        or path_text.startswith(".circleci/")
+        or relative_file.name in {"Jenkinsfile", "azure-pipelines.yml", "azure-pipelines.yaml"}
+        or path_text == ".gitlab-ci.yml"
+    )
+
+
+def is_automation_file(relative_file: Path) -> bool:
+    return is_ci_file(relative_file) or relative_file.name in AUTOMATION_FILE_NAMES
+
+
+def is_entry_point(relative_file: Path) -> bool:
+    if relative_file.name in ENTRY_POINT_FILE_NAMES:
+        return True
+    return bool(relative_file.parts) and relative_file.parts[0] in ENTRY_POINT_DIRECTORIES
+
+
+def _iter_inventory_files(workspace_path: Path) -> Iterable[Path]:
+    for current_root, dirnames, filenames in os.walk(workspace_path, topdown=True):
+        root_path = Path(current_root)
+        relative_root = root_path.relative_to(workspace_path)
+
+        kept_dirnames: list[str] = []
+        for dirname in sorted(dirnames):
+            relative_dir = Path(dirname) if relative_root == Path(".") else relative_root / dirname
+            if not should_ignore_snapshot_path(relative_dir):
+                kept_dirnames.append(dirname)
+        dirnames[:] = kept_dirnames
+
+        for filename in sorted(filenames):
+            relative_file = Path(filename) if relative_root == Path(".") else relative_root / filename
+            if not should_ignore_snapshot_path(relative_file):
+                yield relative_file
+
+
+def _sorted_counter_dict(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}

--- a/src/issue_foundry/repository_inventory.py
+++ b/src/issue_foundry/repository_inventory.py
@@ -164,7 +164,7 @@ def build_repository_inventory(snapshot: MaterializedSourceSnapshot) -> Persiste
     for relative_file in _iter_inventory_files(workspace_path):
         total_files += 1
         file_name = relative_file.name
-        directory_key = relative_file.parent.as_posix() if relative_file.parent != Path(".") else "."
+        directory_key = relative_file.parent.as_posix()
         extension_key = relative_file.suffix.lower() or "<none>"
 
         directory_counts[directory_key] += 1
@@ -176,7 +176,6 @@ def build_repository_inventory(snapshot: MaterializedSourceSnapshot) -> Persiste
 
         relative_path_text = relative_file.as_posix()
         lower_name = file_name.lower()
-        lower_path = relative_path_text.lower()
 
         if lower_name.startswith("readme"):
             readme_files.append(relative_path_text)
@@ -201,9 +200,6 @@ def build_repository_inventory(snapshot: MaterializedSourceSnapshot) -> Persiste
         if file_name in MANIFEST_FILES:
             manifest_files.append(relative_path_text)
             build_systems.update(BUILD_SYSTEMS_BY_FILE.get(file_name, ()))
-            package_managers.update(PACKAGE_MANAGERS_BY_FILE.get(file_name, ()))
-
-        if lower_path.endswith("pnpm-lock.yaml") or lower_path.endswith("yarn.lock"):
             package_managers.update(PACKAGE_MANAGERS_BY_FILE.get(file_name, ()))
 
     artifact = RepositoryInventoryArtifact(
@@ -288,13 +284,13 @@ def _iter_inventory_files(workspace_path: Path) -> Iterable[Path]:
 
         kept_dirnames: list[str] = []
         for dirname in sorted(dirnames):
-            relative_dir = Path(dirname) if relative_root == Path(".") else relative_root / dirname
+            relative_dir = relative_root / dirname
             if not should_ignore_snapshot_path(relative_dir):
                 kept_dirnames.append(dirname)
         dirnames[:] = kept_dirnames
 
         for filename in sorted(filenames):
-            relative_file = Path(filename) if relative_root == Path(".") else relative_root / filename
+            relative_file = relative_root / filename
             if not should_ignore_snapshot_path(relative_file):
                 yield relative_file
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package marker for shared helpers.

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from issue_foundry.inputs import SourceRepositoryInput
+
+
+def create_source_repo(tmp_path: Path) -> tuple[Path, str]:
+    source_repo_path = tmp_path / "source-repo"
+    source_repo_path.mkdir()
+    run_git(["init", "-b", "main"], cwd=source_repo_path)
+    run_git(["config", "user.email", "codex@example.com"], cwd=source_repo_path)
+    run_git(["config", "user.name", "Codex"], cwd=source_repo_path)
+
+    (source_repo_path / "src").mkdir()
+    (source_repo_path / "src" / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    (source_repo_path / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (source_repo_path / "node_modules" / "react").mkdir(parents=True)
+    (source_repo_path / "node_modules" / "react" / "index.js").write_text("module.exports = {};\n", encoding="utf-8")
+
+    run_git(["add", "."], cwd=source_repo_path)
+    run_git(["commit", "-m", "initial snapshot"], cwd=source_repo_path)
+    commit_sha = run_git_capture(["rev-parse", "HEAD"], cwd=source_repo_path)
+    return source_repo_path, commit_sha
+
+
+def build_source_repository_input(source_repo_path: Path) -> SourceRepositoryInput:
+    return SourceRepositoryInput(
+        raw_url=str(source_repo_path),
+        canonical_url=str(source_repo_path),
+        owner="example",
+        name="demo",
+        full_name="example/demo",
+        default_branch="main",
+        display_name="example/demo",
+    )
+
+
+def run_git_capture(args: list[str], *, cwd: Path) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def run_git(args: list[str], *, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_repository_inventory.py
+++ b/tests/test_repository_inventory.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from issue_foundry.config import IssueFoundrySettings
+from issue_foundry.repository_inventory import build_repository_inventory
+from issue_foundry.source_snapshot import materialize_source_snapshot
+from tests.support import build_source_repository_input, create_source_repo, run_git, run_git_capture
+
+
+def test_build_repository_inventory_persists_structural_artifact(tmp_path: Path) -> None:
+    source_repo_path, commit_sha = create_inventory_repo(tmp_path)
+    settings = IssueFoundrySettings(output_dir=tmp_path / ".issue-foundry")
+    source_repository = build_source_repository_input(source_repo_path)
+
+    with materialize_source_snapshot(settings, source_repository, preserve_workspace=False) as snapshot:
+        persisted_inventory = build_repository_inventory(snapshot)
+
+        assert persisted_inventory.artifact.analyzed_commit_sha == commit_sha
+        assert persisted_inventory.artifact.total_files == 10
+        assert persisted_inventory.artifact.detected_languages == (
+            "JSON",
+            "Markdown",
+            "Python",
+            "Shell",
+            "TOML",
+            "YAML",
+        )
+        assert persisted_inventory.artifact.file_counts_by_extension[".py"] == 3
+        assert persisted_inventory.artifact.file_counts_by_directory["docs"] == 1
+        assert persisted_inventory.artifact.file_counts_by_directory["src"] == 2
+        assert persisted_inventory.artifact.language_file_counts["Python"] == 3
+        assert persisted_inventory.artifact.manifest_files == ("package-lock.json", "package.json", "pyproject.toml")
+        assert persisted_inventory.artifact.build_systems == ("node", "python")
+        assert persisted_inventory.artifact.package_managers == ("npm", "pip", "poetry")
+        assert persisted_inventory.artifact.readme_files == ("README.md",)
+        assert persisted_inventory.artifact.documentation_files == ("docs/guide.md",)
+        assert persisted_inventory.artifact.test_files == ("tests/test_app.py",)
+        assert persisted_inventory.artifact.ci_files == (".github/workflows/ci.yml",)
+        assert persisted_inventory.artifact.entry_points == ("src/app.py", "src/main.py")
+        assert "node_modules/" in persisted_inventory.artifact.skipped_paths
+
+        payload = json.loads(persisted_inventory.artifact_path.read_text(encoding="utf-8"))
+        assert payload["analyzed_commit_sha"] == commit_sha
+        assert payload["manifest_files"] == ["package-lock.json", "package.json", "pyproject.toml"]
+
+
+def create_inventory_repo(tmp_path: Path) -> tuple[Path, str]:
+    source_repo_path, commit_sha = create_source_repo(tmp_path)
+
+    (source_repo_path / "tests").mkdir()
+    (source_repo_path / "tests" / "test_app.py").write_text("def test_app():\n    assert True\n", encoding="utf-8")
+    (source_repo_path / "docs").mkdir()
+    (source_repo_path / "docs" / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    (source_repo_path / ".github" / "workflows").mkdir(parents=True)
+    (source_repo_path / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+    (source_repo_path / "src" / "main.py").write_text("print('main')\n", encoding="utf-8")
+    (source_repo_path / "package.json").write_text('{"name":"demo"}\n', encoding="utf-8")
+    (source_repo_path / "package-lock.json").write_text('{"lockfileVersion":3}\n', encoding="utf-8")
+    (source_repo_path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+    (source_repo_path / "scripts").mkdir()
+    (source_repo_path / "scripts" / "dev.sh").write_text("#!/bin/sh\necho demo\n", encoding="utf-8")
+
+    run_git(["add", "."], cwd=source_repo_path)
+    run_git(["commit", "-m", "expand inventory fixture"], cwd=source_repo_path)
+
+    return Path(source_repo_path), run_git_capture(["rev-parse", "HEAD"], cwd=source_repo_path)

--- a/tests/test_source_snapshot.py
+++ b/tests/test_source_snapshot.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
 from pathlib import Path
 
 from issue_foundry.config import IssueFoundrySettings
-from issue_foundry.inputs import SourceRepositoryInput
 from issue_foundry.source_snapshot import materialize_source_snapshot, should_ignore_snapshot_path
+from tests.support import build_source_repository_input, create_source_repo
 
 
 def test_should_ignore_snapshot_path_matches_expected_noise() -> None:
@@ -50,55 +49,3 @@ def test_materialize_source_snapshot_preserves_workspace_when_requested(tmp_path
 
     assert preserved_workspace.exists()
     shutil.rmtree(preserved_workspace)
-
-
-def create_source_repo(tmp_path: Path) -> tuple[Path, str]:
-    source_repo_path = tmp_path / "source-repo"
-    source_repo_path.mkdir()
-    run_git(["init", "-b", "main"], cwd=source_repo_path)
-    run_git(["config", "user.email", "codex@example.com"], cwd=source_repo_path)
-    run_git(["config", "user.name", "Codex"], cwd=source_repo_path)
-
-    (source_repo_path / "src").mkdir()
-    (source_repo_path / "src" / "app.py").write_text("print('hello')\n", encoding="utf-8")
-    (source_repo_path / "README.md").write_text("# Demo\n", encoding="utf-8")
-    (source_repo_path / "node_modules" / "react").mkdir(parents=True)
-    (source_repo_path / "node_modules" / "react" / "index.js").write_text("module.exports = {};\n", encoding="utf-8")
-
-    run_git(["add", "."], cwd=source_repo_path)
-    run_git(["commit", "-m", "initial snapshot"], cwd=source_repo_path)
-    commit_sha = run_git_capture(["rev-parse", "HEAD"], cwd=source_repo_path)
-    return source_repo_path, commit_sha
-
-
-def build_source_repository_input(source_repo_path: Path) -> SourceRepositoryInput:
-    return SourceRepositoryInput(
-        raw_url=str(source_repo_path),
-        canonical_url=str(source_repo_path),
-        owner="example",
-        name="demo",
-        full_name="example/demo",
-        default_branch="main",
-        display_name="example/demo",
-    )
-
-
-def run_git_capture(args: list[str], *, cwd: Path) -> str:
-    completed = subprocess.run(
-        ["git", *args],
-        cwd=cwd,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return completed.stdout.strip()
-
-
-def run_git(args: list[str], *, cwd: Path) -> None:
-    subprocess.run(
-        ["git", *args],
-        cwd=cwd,
-        check=True,
-        capture_output=True,
-        text=True,
-    )


### PR DESCRIPTION
## Summary
- add a deterministic repository inventory stage that reads the materialized source snapshot workspace
- persist `repository-inventory.json` with file counts, language signals, manifests, docs, tests, CI, automation, and entry-point summaries
- wire the `plan` command to run the inventory extractor immediately after source snapshotting

## Why
Issue `#5` needs a stable machine-readable inventory artifact before readable-text extraction and later Codex-driven reasoning can build on the repository structure safely.

## Validation
- `PYTHONPATH=src .venv/bin/pytest -q`
- `PYTHONPATH=src .venv/bin/python -m issue_foundry plan https://github.com/octocat/Hello-World --target-language python`

Closes #5