### PR TITLE
[codex] tighten stage artifact cleanup contracts

### DIFF
--- a/src/issue_foundry/commands/plan.py
+++ b/src/issue_foundry/commands/plan.py
@@ -6,7 +6,8 @@ import typer
 
 from issue_foundry.config import IssueFoundrySettings
 from issue_foundry.inputs import InputValidationError, build_planning_input
-from issue_foundry.repository_inventory import build_repository_inventory
+from issue_foundry.repository_inventory import PersistedRepositoryInventory, build_repository_inventory
+from issue_foundry.source_snapshot import MaterializedSourceSnapshot
 from issue_foundry.source_snapshot import SourceSnapshotError, materialize_source_snapshot
 
 
@@ -39,47 +40,60 @@ def plan(
             preserve_workspace=preserve_workspace,
         ) as snapshot:
             repository_inventory = build_repository_inventory(snapshot)
-            target_request = planning_input.target_request
-
-            typer.echo("Issue Foundry plan scaffold")
-            typer.echo(f"source_repo: {planning_input.source_repository.full_name}")
-            typer.echo(f"source_url: {planning_input.source_repository.canonical_url}")
-            typer.echo(f"default_branch: {planning_input.source_repository.default_branch}")
-            typer.echo(f"display_name: {planning_input.source_repository.display_name}")
-            typer.echo(f"target_repository_name: {target_request.repository_name}")
-            typer.echo(f"target_repository_name_source: {target_request.repository_name_source}")
-            typer.echo(f"target_language: {target_request.language or 'source-aligned defaults'}")
-            typer.echo(f"target_framework: {target_request.framework or 'source-aligned defaults'}")
-            typer.echo(f"target_runtime: {target_request.runtime or 'source-aligned defaults'}")
-            typer.echo(
-                "architecture_constraints: "
-                + (", ".join(target_request.architecture_constraints) if target_request.architecture_constraints else "none")
-            )
-            typer.echo(f"snapshot_commit_sha: {snapshot.artifact.commit_sha}")
-            typer.echo(f"snapshot_resolved_ref: {snapshot.artifact.resolved_ref}")
-            typer.echo(f"snapshot_fetched_at: {snapshot.artifact.fetched_at.isoformat()}")
-            typer.echo(f"snapshot_workspace: {snapshot.workspace_path}")
-            typer.echo(f"snapshot_workspace_retained: {'yes' if snapshot.artifact.workspace_retained else 'no'}")
-            typer.echo(f"snapshot_artifact: {snapshot.artifact_path}")
-            typer.echo(f"snapshot_ignored_paths: {len(snapshot.artifact.ignored_paths)} matched")
-            typer.echo(f"inventory_total_files: {repository_inventory.artifact.total_files}")
-            typer.echo(
-                "inventory_detected_languages: "
-                + (
-                    ", ".join(repository_inventory.artifact.detected_languages)
-                    if repository_inventory.artifact.detected_languages
-                    else "none"
-                )
-            )
-            typer.echo(f"inventory_manifest_files: {len(repository_inventory.artifact.manifest_files)}")
-            typer.echo(f"inventory_test_files: {len(repository_inventory.artifact.test_files)}")
-            typer.echo(f"inventory_doc_files: {len(repository_inventory.artifact.documentation_files)}")
-            typer.echo(f"inventory_ci_files: {len(repository_inventory.artifact.ci_files)}")
-            typer.echo(f"inventory_entry_points: {len(repository_inventory.artifact.entry_points)}")
-            typer.echo(f"inventory_artifact: {repository_inventory.artifact_path}")
-            typer.echo(f"codex_model: {settings.codex_model}")
-            typer.echo(f"output_dir: {settings.output_dir}")
-            typer.echo("next_step: wire readable-text extraction against the repository inventory artifact")
+            _emit_plan_summary(settings, planning_input, snapshot, repository_inventory)
     except SourceSnapshotError as exc:
         typer.secho(f"Error: {exc}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=1) from exc
+
+
+def _emit_plan_summary(
+    settings: IssueFoundrySettings,
+    planning_input,
+    snapshot: MaterializedSourceSnapshot,
+    repository_inventory: PersistedRepositoryInventory,
+) -> None:
+    target_request = planning_input.target_request
+
+    typer.echo("Issue Foundry plan scaffold")
+    typer.echo(f"source_repo: {planning_input.source_repository.full_name}")
+    typer.echo(f"source_url: {planning_input.source_repository.canonical_url}")
+    typer.echo(f"default_branch: {planning_input.source_repository.default_branch}")
+    typer.echo(f"display_name: {planning_input.source_repository.display_name}")
+    typer.echo(f"target_repository_name: {target_request.repository_name}")
+    typer.echo(f"target_repository_name_source: {target_request.repository_name_source}")
+    typer.echo(f"target_language: {target_request.language or 'source-aligned defaults'}")
+    typer.echo(f"target_framework: {target_request.framework or 'source-aligned defaults'}")
+    typer.echo(f"target_runtime: {target_request.runtime or 'source-aligned defaults'}")
+    typer.echo(
+        "architecture_constraints: "
+        + (", ".join(target_request.architecture_constraints) if target_request.architecture_constraints else "none")
+    )
+    typer.echo(f"snapshot_commit_sha: {snapshot.artifact.commit_sha}")
+    typer.echo(f"snapshot_resolved_ref: {snapshot.artifact.resolved_ref}")
+    typer.echo(f"snapshot_fetched_at: {snapshot.artifact.fetched_at.isoformat()}")
+    if snapshot.artifact.workspace_path is not None:
+        typer.echo(f"snapshot_workspace: {snapshot.artifact.workspace_path}")
+    else:
+        typer.echo("snapshot_workspace: temporary workspace cleaned after run")
+    typer.echo(f"snapshot_workspace_retained: {'yes' if snapshot.artifact.workspace_retained else 'no'}")
+    typer.echo(f"snapshot_artifact: {snapshot.artifact_path}")
+    typer.echo(f"snapshot_ignored_paths: {len(snapshot.artifact.ignored_paths)} matched")
+    typer.echo(f"inventory_total_files: {repository_inventory.artifact.total_files}")
+    typer.echo(
+        "inventory_detected_languages: "
+        + (
+            ", ".join(repository_inventory.artifact.detected_languages)
+            if repository_inventory.artifact.detected_languages
+            else "none"
+        )
+    )
+    typer.echo(f"inventory_manifest_files: {len(repository_inventory.artifact.manifest_files)}")
+    typer.echo(f"inventory_test_files: {len(repository_inventory.artifact.test_files)}")
+    typer.echo(f"inventory_doc_files: {len(repository_inventory.artifact.documentation_files)}")
+    typer.echo(f"inventory_ci_files: {len(repository_inventory.artifact.ci_files)}")
+    typer.echo(f"inventory_entry_points: {len(repository_inventory.artifact.entry_points)}")
+    typer.echo(f"inventory_skipped_paths: {len(repository_inventory.artifact.skipped_paths)} matched")
+    typer.echo(f"inventory_artifact: {repository_inventory.artifact_path}")
+    typer.echo(f"codex_model: {settings.codex_model}")
+    typer.echo(f"output_dir: {settings.output_dir}")
+    typer.echo("next_step: wire readable-text extraction against the repository inventory artifact")

--- a/src/issue_foundry/repository_inventory.py
+++ b/src/issue_foundry/repository_inventory.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from pydantic import BaseModel, ConfigDict
 
 from issue_foundry.source_snapshot import MaterializedSourceSnapshot
-from issue_foundry.workspace_tree import scan_workspace_tree
 
 
 LANGUAGE_BY_EXTENSION = {
@@ -134,8 +133,7 @@ class PersistedRepositoryInventory:
 
 
 def build_repository_inventory(snapshot: MaterializedSourceSnapshot) -> PersistedRepositoryInventory:
-    workspace_path = snapshot.workspace_path
-    workspace_tree = scan_workspace_tree(workspace_path)
+    workspace_tree = snapshot.workspace_tree
     extension_counts: Counter[str] = Counter()
     directory_counts: Counter[str] = Counter()
     language_counts: Counter[str] = Counter()

--- a/src/issue_foundry/repository_inventory.py
+++ b/src/issue_foundry/repository_inventory.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import os
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 from pydantic import BaseModel, ConfigDict
 
-from issue_foundry.source_snapshot import MaterializedSourceSnapshot, should_ignore_snapshot_path
+from issue_foundry.source_snapshot import MaterializedSourceSnapshot
+from issue_foundry.workspace_tree import scan_workspace_tree
 
 
 LANGUAGE_BY_EXTENSION = {
@@ -136,6 +135,7 @@ class PersistedRepositoryInventory:
 
 def build_repository_inventory(snapshot: MaterializedSourceSnapshot) -> PersistedRepositoryInventory:
     workspace_path = snapshot.workspace_path
+    workspace_tree = scan_workspace_tree(workspace_path)
     extension_counts: Counter[str] = Counter()
     directory_counts: Counter[str] = Counter()
     language_counts: Counter[str] = Counter()
@@ -147,21 +147,11 @@ def build_repository_inventory(snapshot: MaterializedSourceSnapshot) -> Persiste
     ci_files: list[str] = []
     automation_files: list[str] = []
     entry_points: list[str] = []
-    top_level_directories: list[str] = []
-    top_level_files: list[str] = []
     package_managers: set[str] = set()
     build_systems: set[str] = set()
 
-    for child in sorted(workspace_path.iterdir(), key=lambda path: path.name):
-        if should_ignore_snapshot_path(Path(child.name)):
-            continue
-        if child.is_dir():
-            top_level_directories.append(child.name)
-        else:
-            top_level_files.append(child.name)
-
     total_files = 0
-    for relative_file in _iter_inventory_files(workspace_path):
+    for relative_file in workspace_tree.files:
         total_files += 1
         file_name = relative_file.name
         directory_key = relative_file.parent.as_posix()
@@ -206,8 +196,8 @@ def build_repository_inventory(snapshot: MaterializedSourceSnapshot) -> Persiste
         source_snapshot_artifact_path=str(snapshot.artifact_path),
         analyzed_commit_sha=snapshot.artifact.commit_sha,
         total_files=total_files,
-        top_level_directories=tuple(top_level_directories),
-        top_level_files=tuple(top_level_files),
+        top_level_directories=workspace_tree.top_level_directories,
+        top_level_files=workspace_tree.top_level_files,
         file_counts_by_extension=_sorted_counter_dict(extension_counts),
         file_counts_by_directory=_sorted_counter_dict(directory_counts),
         language_file_counts=_sorted_counter_dict(language_counts),
@@ -222,7 +212,7 @@ def build_repository_inventory(snapshot: MaterializedSourceSnapshot) -> Persiste
         ci_files=tuple(sorted(ci_files)),
         automation_files=tuple(sorted(set(automation_files))),
         entry_points=tuple(sorted(set(entry_points))),
-        skipped_paths=snapshot.artifact.ignored_paths,
+        skipped_paths=workspace_tree.skipped_paths,
     )
 
     artifact_path = write_repository_inventory_artifact(snapshot, artifact)
@@ -275,24 +265,6 @@ def is_entry_point(relative_file: Path) -> bool:
     if relative_file.name in ENTRY_POINT_FILE_NAMES:
         return True
     return bool(relative_file.parts) and relative_file.parts[0] in ENTRY_POINT_DIRECTORIES
-
-
-def _iter_inventory_files(workspace_path: Path) -> Iterable[Path]:
-    for current_root, dirnames, filenames in os.walk(workspace_path, topdown=True):
-        root_path = Path(current_root)
-        relative_root = root_path.relative_to(workspace_path)
-
-        kept_dirnames: list[str] = []
-        for dirname in sorted(dirnames):
-            relative_dir = relative_root / dirname
-            if not should_ignore_snapshot_path(relative_dir):
-                kept_dirnames.append(dirname)
-        dirnames[:] = kept_dirnames
-
-        for filename in sorted(filenames):
-            relative_file = relative_root / filename
-            if not should_ignore_snapshot_path(relative_file):
-                yield relative_file
 
 
 def _sorted_counter_dict(counter: Counter[str]) -> dict[str, int]:

--- a/src/issue_foundry/source_snapshot.py
+++ b/src/issue_foundry/source_snapshot.py
@@ -13,7 +13,13 @@ from pydantic import BaseModel, ConfigDict
 
 from issue_foundry.config import IssueFoundrySettings
 from issue_foundry.inputs import SourceRepositoryInput
-from issue_foundry.workspace_tree import IGNORED_FILE_NAMES, IGNORED_PATH_PARTS, scan_workspace_tree
+from issue_foundry.workspace_tree import (
+    IGNORED_FILE_NAMES,
+    IGNORED_PATH_PARTS,
+    WorkspaceTree,
+    scan_workspace_tree,
+    should_ignore_repository_path,
+)
 
 
 class SourceSnapshotError(RuntimeError):
@@ -42,6 +48,7 @@ class MaterializedSourceSnapshot:
     artifact: SourceSnapshotArtifact
     artifact_path: Path
     workspace_path: Path
+    workspace_tree: WorkspaceTree
     _temporary_directory: Any = None
 
     def cleanup(self) -> None:
@@ -108,6 +115,7 @@ def create_source_snapshot(
             artifact=artifact,
             artifact_path=artifact_path,
             workspace_path=workspace_path,
+            workspace_tree=workspace_tree,
             _temporary_directory=temporary_directory,
         )
     except Exception:
@@ -127,8 +135,6 @@ def write_source_snapshot_artifact(output_dir: Path, artifact: SourceSnapshotArt
 
 
 def should_ignore_snapshot_path(relative_path: Path) -> bool:
-    from issue_foundry.workspace_tree import should_ignore_repository_path
-
     return should_ignore_repository_path(relative_path)
 
 

--- a/src/issue_foundry/source_snapshot.py
+++ b/src/issue_foundry/source_snapshot.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 from contextlib import contextmanager
@@ -14,30 +13,7 @@ from pydantic import BaseModel, ConfigDict
 
 from issue_foundry.config import IssueFoundrySettings
 from issue_foundry.inputs import SourceRepositoryInput
-
-
-IGNORED_PATH_PARTS = frozenset(
-    {
-        ".git",
-        ".hg",
-        ".svn",
-        ".venv",
-        ".yarn",
-        "__pycache__",
-        ".mypy_cache",
-        ".pytest_cache",
-        ".ruff_cache",
-        ".tox",
-        "build",
-        "coverage",
-        "dist",
-        "node_modules",
-        "target",
-        "vendor",
-        "venv",
-    }
-)
-IGNORED_FILE_NAMES = frozenset({".DS_Store"})
+from issue_foundry.workspace_tree import IGNORED_FILE_NAMES, IGNORED_PATH_PARTS, scan_workspace_tree
 
 
 class SourceSnapshotError(RuntimeError):
@@ -53,7 +29,7 @@ class SourceSnapshotArtifact(BaseModel):
     resolved_ref: str
     commit_sha: str
     fetched_at: datetime
-    workspace_path: str
+    workspace_path: Optional[str]
     workspace_retained: bool
     ignore_rules: tuple[str, ...]
     ignored_paths: tuple[str, ...]
@@ -116,16 +92,16 @@ def create_source_snapshot(
         )
         commit_sha = _run_git_capture(["rev-parse", "HEAD"], cwd=workspace_path)
         fetched_at = datetime.now(timezone.utc)
-        ignored_paths = collect_ignored_paths(workspace_path)
+        workspace_tree = scan_workspace_tree(workspace_path)
         artifact = SourceSnapshotArtifact(
             source_repository=source_repository,
             resolved_ref=resolved_ref,
             commit_sha=commit_sha,
             fetched_at=fetched_at,
-            workspace_path=str(workspace_path),
+            workspace_path=str(workspace_path) if preserve_workspace else None,
             workspace_retained=preserve_workspace,
             ignore_rules=tuple(sorted(IGNORED_PATH_PARTS)) + tuple(sorted(IGNORED_FILE_NAMES)),
-            ignored_paths=ignored_paths,
+            ignored_paths=workspace_tree.skipped_paths,
         )
         artifact_path = write_source_snapshot_artifact(output_dir, artifact)
         return MaterializedSourceSnapshot(
@@ -151,38 +127,13 @@ def write_source_snapshot_artifact(output_dir: Path, artifact: SourceSnapshotArt
 
 
 def should_ignore_snapshot_path(relative_path: Path) -> bool:
-    if relative_path.name in IGNORED_FILE_NAMES:
-        return True
+    from issue_foundry.workspace_tree import should_ignore_repository_path
 
-    return any(part in IGNORED_PATH_PARTS for part in relative_path.parts)
+    return should_ignore_repository_path(relative_path)
 
 
 def collect_ignored_paths(workspace_path: Path, *, limit: int = 200) -> tuple[str, ...]:
-    ignored_paths: list[str] = []
-
-    for current_root, dirnames, filenames in os.walk(workspace_path, topdown=True):
-        root_path = Path(current_root)
-        relative_root = root_path.relative_to(workspace_path)
-
-        kept_dirnames: list[str] = []
-        for dirname in sorted(dirnames):
-            relative_dir = relative_root / dirname
-            if should_ignore_snapshot_path(relative_dir):
-                ignored_paths.append(f"{relative_dir.as_posix()}/")
-                if len(ignored_paths) >= limit:
-                    return tuple(ignored_paths)
-            else:
-                kept_dirnames.append(dirname)
-        dirnames[:] = kept_dirnames
-
-        for filename in sorted(filenames):
-            relative_file = relative_root / filename
-            if should_ignore_snapshot_path(relative_file):
-                ignored_paths.append(relative_file.as_posix())
-                if len(ignored_paths) >= limit:
-                    return tuple(ignored_paths)
-
-    return tuple(ignored_paths)
+    return scan_workspace_tree(workspace_path, skipped_limit=limit).skipped_paths
 
 
 def _allocate_workspace(

--- a/src/issue_foundry/workspace_tree.py
+++ b/src/issue_foundry/workspace_tree.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+IGNORED_PATH_PARTS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        ".venv",
+        ".yarn",
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        "build",
+        "coverage",
+        "dist",
+        "node_modules",
+        "target",
+        "vendor",
+        "venv",
+    }
+)
+IGNORED_FILE_NAMES = frozenset({".DS_Store"})
+
+
+@dataclass(frozen=True)
+class WorkspaceTree:
+    files: tuple[Path, ...]
+    top_level_directories: tuple[str, ...]
+    top_level_files: tuple[str, ...]
+    skipped_paths: tuple[str, ...]
+
+
+def should_ignore_repository_path(relative_path: Path) -> bool:
+    if relative_path.name in IGNORED_FILE_NAMES:
+        return True
+
+    return any(part in IGNORED_PATH_PARTS for part in relative_path.parts)
+
+
+def scan_workspace_tree(workspace_path: Path, *, skipped_limit: int = 200) -> WorkspaceTree:
+    files: list[Path] = []
+    top_level_directories: list[str] = []
+    top_level_files: list[str] = []
+    skipped_paths: list[str] = []
+
+    for current_root, dirnames, filenames in os.walk(workspace_path, topdown=True):
+        root_path = Path(current_root)
+        relative_root = root_path.relative_to(workspace_path)
+
+        kept_dirnames: list[str] = []
+        for dirname in sorted(dirnames):
+            relative_dir = relative_root / dirname
+            if should_ignore_repository_path(relative_dir):
+                _record_skipped_path(skipped_paths, f"{relative_dir.as_posix()}/", limit=skipped_limit)
+            else:
+                kept_dirnames.append(dirname)
+                if relative_root == Path("."):
+                    top_level_directories.append(dirname)
+        dirnames[:] = kept_dirnames
+
+        for filename in sorted(filenames):
+            relative_file = relative_root / filename
+            if should_ignore_repository_path(relative_file):
+                _record_skipped_path(skipped_paths, relative_file.as_posix(), limit=skipped_limit)
+            else:
+                files.append(relative_file)
+                if relative_root == Path("."):
+                    top_level_files.append(filename)
+
+    return WorkspaceTree(
+        files=tuple(files),
+        top_level_directories=tuple(top_level_directories),
+        top_level_files=tuple(top_level_files),
+        skipped_paths=tuple(skipped_paths),
+    )
+
+
+def _record_skipped_path(skipped_paths: list[str], value: str, *, limit: int) -> None:
+    if len(skipped_paths) >= limit:
+        return
+    skipped_paths.append(value)

--- a/tests/test_repository_inventory.py
+++ b/tests/test_repository_inventory.py
@@ -40,6 +40,7 @@ def test_build_repository_inventory_persists_structural_artifact(tmp_path: Path)
         assert persisted_inventory.artifact.ci_files == (".github/workflows/ci.yml",)
         assert persisted_inventory.artifact.entry_points == ("src/app.py", "src/main.py")
         assert "node_modules/" in persisted_inventory.artifact.skipped_paths
+        assert persisted_inventory.artifact.skipped_paths == snapshot.artifact.ignored_paths
 
         payload = json.loads(persisted_inventory.artifact_path.read_text(encoding="utf-8"))
         assert payload["analyzed_commit_sha"] == commit_sha

--- a/tests/test_source_snapshot.py
+++ b/tests/test_source_snapshot.py
@@ -28,10 +28,12 @@ def test_materialize_source_snapshot_cleans_temp_workspace(tmp_path: Path) -> No
         assert snapshot.artifact.commit_sha == commit_sha
         assert snapshot.artifact.resolved_ref == "main"
         assert snapshot.artifact.workspace_retained is False
+        assert snapshot.artifact.workspace_path is None
         assert "node_modules/" in snapshot.artifact.ignored_paths
         artifact_payload = json.loads(snapshot.artifact_path.read_text(encoding="utf-8"))
         assert artifact_payload["commit_sha"] == commit_sha
         assert artifact_payload["resolved_ref"] == "main"
+        assert artifact_payload["workspace_path"] is None
 
     assert not snapshot.workspace_path.exists()
 
@@ -46,6 +48,7 @@ def test_materialize_source_snapshot_preserves_workspace_when_requested(tmp_path
         assert preserved_workspace.exists()
         assert snapshot.artifact.commit_sha == commit_sha
         assert snapshot.artifact.workspace_retained is True
+        assert snapshot.artifact.workspace_path == str(preserved_workspace)
 
     assert preserved_workspace.exists()
     shutil.rmtree(preserved_workspace)


### PR DESCRIPTION
## Summary
- consolidate shared workspace ignore and traversal behavior into a single `workspace_tree` module
- stop publishing dead temp-workspace paths in snapshot artifacts and `plan` output when the workspace will be cleaned automatically
- make the inventory stage compute and report its own skipped-path summary while simplifying `plan` summary rendering

## Why
Issue `#32` tracks an audit pass over the current implementation. This cleanup removes early duplication and fixes inconsistent artifact semantics before more investigation stages build on the snapshot and inventory contracts.

## Validation
- `PYTHONPATH=src .venv/bin/pytest -q`
- `PYTHONPATH=src .venv/bin/python -m issue_foundry plan https://github.com/octocat/Hello-World --target-language python`
- `PYTHONPATH=src .venv/bin/python -m issue_foundry plan https://github.com/octocat/Hello-World --target-language python --preserve-workspace`

Closes #32