### PR TITLE
[codex] extract readable text evidence from source repositories

### DIFF
--- a/src/issue_foundry/commands/plan.py
+++ b/src/issue_foundry/commands/plan.py
@@ -6,6 +6,7 @@ import typer
 
 from issue_foundry.config import IssueFoundrySettings
 from issue_foundry.inputs import InputValidationError, build_planning_input
+from issue_foundry.readable_text_evidence import PersistedReadableTextEvidence, build_readable_text_evidence
 from issue_foundry.repository_inventory import PersistedRepositoryInventory, build_repository_inventory
 from issue_foundry.source_snapshot import MaterializedSourceSnapshot
 from issue_foundry.source_snapshot import SourceSnapshotError, materialize_source_snapshot
@@ -40,7 +41,8 @@ def plan(
             preserve_workspace=preserve_workspace,
         ) as snapshot:
             repository_inventory = build_repository_inventory(snapshot)
-            _emit_plan_summary(settings, planning_input, snapshot, repository_inventory)
+            readable_text_evidence = build_readable_text_evidence(snapshot, repository_inventory)
+            _emit_plan_summary(settings, planning_input, snapshot, repository_inventory, readable_text_evidence)
     except SourceSnapshotError as exc:
         typer.secho(f"Error: {exc}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=1) from exc
@@ -51,6 +53,7 @@ def _emit_plan_summary(
     planning_input,
     snapshot: MaterializedSourceSnapshot,
     repository_inventory: PersistedRepositoryInventory,
+    readable_text_evidence: PersistedReadableTextEvidence,
 ) -> None:
     target_request = planning_input.target_request
 
@@ -94,6 +97,11 @@ def _emit_plan_summary(
     typer.echo(f"inventory_entry_points: {len(repository_inventory.artifact.entry_points)}")
     typer.echo(f"inventory_skipped_paths: {len(repository_inventory.artifact.skipped_paths)} matched")
     typer.echo(f"inventory_artifact: {repository_inventory.artifact_path}")
+    typer.echo(f"text_evidence_documents: {readable_text_evidence.artifact.total_documents}")
+    typer.echo(f"text_evidence_clues: {readable_text_evidence.artifact.total_clues}")
+    typer.echo(f"text_evidence_commands: {readable_text_evidence.artifact.command_clues}")
+    typer.echo(f"text_evidence_skipped_files: {len(readable_text_evidence.artifact.skipped_files)}")
+    typer.echo(f"text_evidence_artifact: {readable_text_evidence.artifact_path}")
     typer.echo(f"codex_model: {settings.codex_model}")
     typer.echo(f"output_dir: {settings.output_dir}")
-    typer.echo("next_step: wire readable-text extraction against the repository inventory artifact")
+    typer.echo("next_step: wire architecture synthesis against the inventory and readable-text artifacts")

--- a/src/issue_foundry/readable_text_evidence.py
+++ b/src/issue_foundry/readable_text_evidence.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from issue_foundry.repository_inventory import PersistedRepositoryInventory, RepositoryInventoryArtifact
+from issue_foundry.source_snapshot import MaterializedSourceSnapshot
+
+
+TEXT_BYTES_LIMIT = 64_000
+MAX_HEADINGS_PER_DOCUMENT = 12
+MAX_CLUES_PER_DOCUMENT = 24
+SHELL_FENCE_LANGUAGES = {"", "bash", "console", "shell", "sh", "zsh"}
+COMMAND_PREFIXES = {
+    "./",
+    "bundle",
+    "cargo",
+    "curl",
+    "docker",
+    "gh",
+    "go",
+    "make",
+    "node",
+    "npm",
+    "pip",
+    "pnpm",
+    "poetry",
+    "python",
+    "rails",
+    "uv",
+    "wget",
+    "yarn",
+}
+CLUE_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("deployment", ("deploy", "deployment", "docker", "container", "kubernetes", "production", "release")),
+    ("setup", ("install", "installation", "setup", "quickstart", "getting started", "prerequisite")),
+    ("api", ("api", "endpoint", "request", "response", "webhook", "graphql", "rest")),
+    ("usage", ("usage", "run", "start", "invoke", "command", "cli")),
+    ("constraint", ("requires", "must", "only", "limitation", "constraint", "unsupported", "warning", "note")),
+    ("feature", ("feature", "supports", "provides", "allows", "enables")),
+)
+
+
+class ReadableTextClue(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["command", "constraint", "deployment", "feature", "setup", "usage", "api"]
+    line_number: int
+    text: str
+
+
+class ReadableTextDocument(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    path: str
+    category: Literal["readme", "documentation", "plain_text"]
+    size_bytes: int
+    line_count: int
+    truncated: bool
+    headings: tuple[str, ...]
+    clues: tuple[ReadableTextClue, ...]
+
+
+class ReadableTextEvidenceArtifact(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    source_snapshot_artifact_path: str
+    repository_inventory_artifact_path: str
+    analyzed_commit_sha: str
+    documents: tuple[ReadableTextDocument, ...]
+    skipped_files: tuple[str, ...]
+    total_documents: int
+    total_clues: int
+    command_clues: int
+
+
+@dataclass
+class PersistedReadableTextEvidence:
+    artifact: ReadableTextEvidenceArtifact
+    artifact_path: Path
+
+
+def build_readable_text_evidence(
+    snapshot: MaterializedSourceSnapshot,
+    repository_inventory: PersistedRepositoryInventory,
+) -> PersistedReadableTextEvidence:
+    documents: list[ReadableTextDocument] = []
+    skipped_files: list[str] = []
+
+    for path_text, category in iter_readable_text_candidates(repository_inventory.artifact):
+        document = _extract_readable_text_document(snapshot.workspace_path, path_text=path_text, category=category)
+        if document is None:
+            skipped_files.append(path_text)
+            continue
+        documents.append(document)
+
+    total_clues = sum(len(document.clues) for document in documents)
+    command_clues = sum(
+        1 for document in documents for clue in document.clues if clue.kind == "command"
+    )
+    artifact = ReadableTextEvidenceArtifact(
+        source_snapshot_artifact_path=str(snapshot.artifact_path),
+        repository_inventory_artifact_path=str(repository_inventory.artifact_path),
+        analyzed_commit_sha=snapshot.artifact.commit_sha,
+        documents=tuple(documents),
+        skipped_files=tuple(sorted(skipped_files)),
+        total_documents=len(documents),
+        total_clues=total_clues,
+        command_clues=command_clues,
+    )
+    artifact_path = write_readable_text_evidence_artifact(snapshot, artifact)
+    return PersistedReadableTextEvidence(artifact=artifact, artifact_path=artifact_path)
+
+
+def write_readable_text_evidence_artifact(
+    snapshot: MaterializedSourceSnapshot,
+    artifact: ReadableTextEvidenceArtifact,
+) -> Path:
+    artifact_dir = snapshot.artifact_path.parent
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact_dir / "readable-text-evidence.json"
+    artifact_path.write_text(artifact.model_dump_json(indent=2), encoding="utf-8")
+    return artifact_path
+
+
+def iter_readable_text_candidates(
+    inventory: RepositoryInventoryArtifact,
+) -> tuple[tuple[str, Literal["readme", "documentation", "plain_text"]], ...]:
+    categories = (
+        ("readme", inventory.readme_files),
+        ("documentation", inventory.documentation_files),
+        ("plain_text", inventory.plain_text_files),
+    )
+
+    ordered_paths: dict[str, Literal["readme", "documentation", "plain_text"]] = {}
+    for category, paths in categories:
+        for path_text in sorted(paths):
+            ordered_paths.setdefault(path_text, category)
+
+    return tuple((path_text, ordered_paths[path_text]) for path_text in ordered_paths)
+
+
+def _extract_readable_text_document(
+    workspace_path: Path,
+    *,
+    path_text: str,
+    category: Literal["readme", "documentation", "plain_text"],
+) -> ReadableTextDocument | None:
+    candidate_path = workspace_path / path_text
+    if not candidate_path.is_file():
+        return None
+
+    raw_bytes = candidate_path.read_bytes()
+    if not raw_bytes:
+        return None
+    if b"\0" in raw_bytes[:TEXT_BYTES_LIMIT]:
+        return None
+
+    truncated = len(raw_bytes) > TEXT_BYTES_LIMIT
+    decoded_text = raw_bytes[:TEXT_BYTES_LIMIT].decode("utf-8", errors="ignore")
+    normalized_text = decoded_text.replace("\r\n", "\n").replace("\r", "\n")
+    if not normalized_text.strip():
+        return None
+
+    headings, clues = _extract_headings_and_clues(normalized_text)
+    return ReadableTextDocument(
+        path=path_text,
+        category=category,
+        size_bytes=len(raw_bytes),
+        line_count=len(normalized_text.splitlines()),
+        truncated=truncated,
+        headings=headings,
+        clues=clues,
+    )
+
+
+def _extract_headings_and_clues(text: str) -> tuple[tuple[str, ...], tuple[ReadableTextClue, ...]]:
+    headings: list[str] = []
+    clues: list[ReadableTextClue] = []
+    seen_clues: set[tuple[str, str]] = set()
+    in_shell_block = False
+
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        stripped_line = raw_line.strip()
+        if not stripped_line:
+            continue
+
+        if stripped_line.startswith("```"):
+            fence_language = stripped_line[3:].strip().lower()
+            if in_shell_block:
+                in_shell_block = False
+            else:
+                in_shell_block = fence_language in SHELL_FENCE_LANGUAGES
+            continue
+
+        heading = _extract_markdown_heading(stripped_line)
+        if heading is not None:
+            if len(headings) < MAX_HEADINGS_PER_DOCUMENT:
+                headings.append(heading)
+            continue
+
+        if in_shell_block and _looks_like_command(stripped_line):
+            _append_clue(clues, seen_clues, kind="command", line_number=line_number, text=_normalize_clue_text(stripped_line))
+            continue
+
+        for inline_command in _extract_inline_commands(stripped_line):
+            _append_clue(clues, seen_clues, kind="command", line_number=line_number, text=inline_command)
+
+        line_kind = _classify_line(stripped_line)
+        if line_kind is not None:
+            _append_clue(
+                clues,
+                seen_clues,
+                kind=line_kind,
+                line_number=line_number,
+                text=_normalize_clue_text(stripped_line),
+            )
+
+    return tuple(headings), tuple(clues)
+
+
+def _extract_markdown_heading(stripped_line: str) -> str | None:
+    if not stripped_line.startswith("#"):
+        return None
+
+    heading = stripped_line.lstrip("#").strip()
+    return heading or None
+
+
+def _extract_inline_commands(stripped_line: str) -> tuple[str, ...]:
+    commands: list[str] = []
+
+    if stripped_line.startswith("$ "):
+        commands.append(_normalize_clue_text(stripped_line[2:]))
+
+    for inline_text in re.findall(r"`([^`]+)`", stripped_line):
+        if _looks_like_command(inline_text):
+            commands.append(_normalize_clue_text(inline_text))
+
+    deduped_commands: list[str] = []
+    seen_commands: set[str] = set()
+    for command in commands:
+        if command in seen_commands:
+            continue
+        seen_commands.add(command)
+        deduped_commands.append(command)
+    return tuple(deduped_commands)
+
+
+def _looks_like_command(candidate: str) -> bool:
+    normalized = candidate.strip().lstrip("$").strip()
+    if not normalized:
+        return False
+
+    first_token = normalized.split()[0]
+    if first_token.startswith("./"):
+        return True
+
+    if first_token in COMMAND_PREFIXES:
+        return True
+
+    return " -m " in normalized or normalized.startswith("python ")
+
+
+def _classify_line(stripped_line: str) -> Literal["constraint", "deployment", "feature", "setup", "usage", "api"] | None:
+    lowered = stripped_line.lower()
+    content = re.sub(r"^[\s*.\-0-9)]+", "", lowered).strip()
+    if not content:
+        return None
+
+    for clue_kind, keywords in CLUE_KEYWORDS:
+        if any(keyword in content for keyword in keywords):
+            return clue_kind  # type: ignore[return-value]
+    return None
+
+
+def _append_clue(
+    clues: list[ReadableTextClue],
+    seen_clues: set[tuple[str, str]],
+    *,
+    kind: Literal["command", "constraint", "deployment", "feature", "setup", "usage", "api"],
+    line_number: int,
+    text: str,
+) -> None:
+    if len(clues) >= MAX_CLUES_PER_DOCUMENT:
+        return
+    if not text:
+        return
+
+    fingerprint = (kind, text)
+    if fingerprint in seen_clues:
+        return
+    seen_clues.add(fingerprint)
+    clues.append(ReadableTextClue(kind=kind, line_number=line_number, text=text))
+
+
+def _normalize_clue_text(value: str) -> str:
+    return " ".join(value.split())[:280]

--- a/tests/test_readable_text_evidence.py
+++ b/tests/test_readable_text_evidence.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from issue_foundry.config import IssueFoundrySettings
+from issue_foundry.readable_text_evidence import build_readable_text_evidence
+from issue_foundry.repository_inventory import build_repository_inventory
+from issue_foundry.source_snapshot import materialize_source_snapshot
+from tests.support import build_source_repository_input, create_source_repo, run_git, run_git_capture
+
+
+def test_build_readable_text_evidence_persists_structured_text_artifact(tmp_path: Path) -> None:
+    source_repo_path, commit_sha = create_readable_text_repo(tmp_path)
+    settings = IssueFoundrySettings(output_dir=tmp_path / ".issue-foundry")
+    source_repository = build_source_repository_input(source_repo_path)
+
+    with materialize_source_snapshot(settings, source_repository, preserve_workspace=False) as snapshot:
+        repository_inventory = build_repository_inventory(snapshot)
+        readable_text_evidence = build_readable_text_evidence(snapshot, repository_inventory)
+
+        assert readable_text_evidence.artifact.analyzed_commit_sha == commit_sha
+        assert readable_text_evidence.artifact.total_documents == 5
+        assert readable_text_evidence.artifact.command_clues >= 2
+        assert readable_text_evidence.artifact.total_clues >= 8
+        assert readable_text_evidence.artifact.skipped_files == ()
+
+        documents = {document.path: document for document in readable_text_evidence.artifact.documents}
+        assert documents["README.md"].category == "readme"
+        assert "Demo Service" in documents["README.md"].headings
+        assert any(clue.kind == "setup" for clue in documents["README.md"].clues)
+        assert any(clue.kind == "command" and "python -m demo serve" in clue.text for clue in documents["README.md"].clues)
+        assert documents["docs/guide.md"].category == "documentation"
+        assert any(clue.kind == "deployment" for clue in documents["docs/guide.md"].clues)
+        assert any(clue.kind == "constraint" for clue in documents["docs/adr/0001-runtime.md"].clues)
+        assert documents["CHANGELOG.md"].category == "documentation"
+
+        payload = json.loads(readable_text_evidence.artifact_path.read_text(encoding="utf-8"))
+        assert payload["analyzed_commit_sha"] == commit_sha
+        assert payload["total_documents"] == 5
+        assert payload["repository_inventory_artifact_path"].endswith("repository-inventory.json")
+
+
+def test_build_readable_text_evidence_skips_binary_text_candidates(tmp_path: Path) -> None:
+    source_repo_path, _ = create_readable_text_repo(tmp_path)
+    (source_repo_path / "docs" / "binary.txt").write_bytes(b"\x00\xff\x00")
+    run_git(["add", "."], cwd=source_repo_path)
+    run_git(["commit", "-m", "add binary text candidate"], cwd=source_repo_path)
+
+    settings = IssueFoundrySettings(output_dir=tmp_path / ".issue-foundry")
+    source_repository = build_source_repository_input(source_repo_path)
+
+    with materialize_source_snapshot(settings, source_repository, preserve_workspace=False) as snapshot:
+        repository_inventory = build_repository_inventory(snapshot)
+        readable_text_evidence = build_readable_text_evidence(snapshot, repository_inventory)
+
+        assert "docs/binary.txt" in readable_text_evidence.artifact.skipped_files
+        assert readable_text_evidence.artifact.total_documents == 5
+
+
+def create_readable_text_repo(tmp_path: Path) -> tuple[Path, str]:
+    source_repo_path, _ = create_source_repo(tmp_path)
+
+    (source_repo_path / "README.md").write_text(
+        "\n".join(
+            [
+                "# Demo Service",
+                "",
+                "Install the dependencies with `pip install -e .` before local development.",
+                "Run `python -m demo serve` to start the CLI service locally.",
+                "The CLI provides background sync and export features.",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (source_repo_path / "docs").mkdir()
+    (source_repo_path / "docs" / "guide.md").write_text(
+        "\n".join(
+            [
+                "# Operations Guide",
+                "",
+                "Deploy with Docker Compose in production.",
+                "The HTTP API exposes `/health` and `/sync` endpoints.",
+                "",
+                "```bash",
+                "docker compose up --build",
+                "```",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (source_repo_path / "docs" / "adr").mkdir()
+    (source_repo_path / "docs" / "adr" / "0001-runtime.md").write_text(
+        "\n".join(
+            [
+                "# ADR 0001",
+                "",
+                "The service requires Python 3.12 and only supports SQLite for local mode.",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (source_repo_path / "CHANGELOG.md").write_text(
+        "\n".join(
+            [
+                "# Changelog",
+                "",
+                "- Release 0.2 adds export support.",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (source_repo_path / "NOTES.txt").write_text(
+        "Usage note: run ./scripts/dev.sh to seed demo data.\n",
+        encoding="utf-8",
+    )
+    (source_repo_path / "scripts").mkdir()
+    (source_repo_path / "scripts" / "dev.sh").write_text("#!/bin/sh\necho demo\n", encoding="utf-8")
+
+    run_git(["add", "."], cwd=source_repo_path)
+    run_git(["commit", "-m", "add readable text fixtures"], cwd=source_repo_path)
+
+    return Path(source_repo_path), run_git_capture(["rev-parse", "HEAD"], cwd=source_repo_path)


### PR DESCRIPTION
## Summary
- add a deterministic readable-text extraction stage that turns README, docs, changelog, ADR, and plain-text files into a structured `readable-text-evidence.json` artifact
- preserve per-document provenance plus normalized clues for setup, usage, API, deployment, constraints, features, and commands
- wire `plan` to emit readable-text artifact counts and add focused tests for structured extraction and graceful skipping of binary text candidates

## Why
Issue `#22` needs a readable-text evidence corpus before later architecture synthesis and Codex planning stages can combine human-authored repository guidance with the structural inventory.

## Validation
- `PYTHONPATH=src .venv/bin/pytest -q`
- `PYTHONPATH=src .venv/bin/python -m issue_foundry plan https://github.com/octocat/Hello-World --target-language python`

Closes #22